### PR TITLE
View / Download Links Fail when "Download" is default option

### DIFF
--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -210,7 +210,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since  4.0
 	 */
 	public function apply_backwards_compatibility_filters( $settings, $entry ) {
-		
+
 		$form = $this->form->get_form( $entry['form_id'] );
 
 		$settings['filename'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_pdf_name', $settings['filename'], $form, $entry ) );
@@ -430,7 +430,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			/* check if the user is logged in but is not the current owner */
 			if ( is_user_logged_in() &&
 				( ( $this->options->get_option( 'limit_to_admin', 'No' ) == 'Yes' ) || ( $this->is_current_pdf_owner( $entry, 'logged_in' ) === false ) ) ) {
-				
+
 				/* Handle permissions checks */
 				$admin_permissions = $this->options->get_option( 'admin_capabilities', array( 'gravityforms_view_entries' ) );
 
@@ -471,12 +471,21 @@ class Model_PDF extends Helper_Abstract_Model {
 		) );
 
 		if ( ! empty($pdf_list) ) {
+
 			if ( sizeof( $pdf_list ) > 1 ) {
-				$args = array( 'pdfs' => $pdf_list );
+				$args = array(
+                    'pdfs' => $pdf_list,
+                    'view' => strtolower( $this->options->get_option( 'default_action' ) ),
+				);
+
 				$controller->view->entry_list_pdf_multiple( $args );
 			} else {
 				/* Only one PDF for this form so display a simple 'View PDF' link */
-				$args = array_shift( $pdf_list );
+				$args = array(
+                    'pdf'  => array_shift( $pdf_list ),
+                    'view' => strtolower( $this->options->get_option( 'default_action' ) ),
+				);
+
 				$controller->view->entry_list_pdf_single( $args );
 			}
 		}
@@ -500,7 +509,9 @@ class Model_PDF extends Helper_Abstract_Model {
 		) );
 
 		if ( ! empty($pdf_list) ) {
-			$args = array( 'pdfs' => $pdf_list );
+			$args = array(
+				'pdfs' => $pdf_list
+			);			
 			$controller->view->entry_detailed_pdf( $args );
 		}
 	}
@@ -521,13 +532,13 @@ class Model_PDF extends Helper_Abstract_Model {
 		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : array();
 
 		if ( ! empty($pdfs) ) {
-			$download = ($this->options->get_option( 'default_action' ) == 'Download') ? true : false;
 
 			foreach ( $pdfs as $pdf ) {
 
 				$args[] = array(
-					'name' => $this->get_pdf_name( $pdf, $entry ),
-					'url'  => $this->get_pdf_url( $pdf['id'], $entry['id'], $download ),
+                    'name'     => $this->get_pdf_name( $pdf, $entry ),
+                    'view'     => $this->get_pdf_url( $pdf['id'], $entry['id'], false ),
+                    'download' => $this->get_pdf_url( $pdf['id'], $entry['id'], true ),
 				);
 			}
 		}
@@ -700,7 +711,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			}
 
 			$notifications['attachments'] = ( isset( $notifications['attachments'] ) ) ? $notifications['attachments'] : array();
-			
+
 			$this->log->addNotice( 'Gravity Forms Attachments', array(
 				'attachments'  => $notifications['attachments'],
 				'notification' => $notifications,
@@ -869,7 +880,7 @@ class Model_PDF extends Helper_Abstract_Model {
 						try {
 							$this->misc->rmdir( $pdf_generator->get_path() );
 						} catch (Exception $e) {
-							
+
 							$this->log->addError( 'Cleanup PDF Error', array(
 								'pdf'       => $pdf,
 								'exception' => $e,
@@ -940,7 +951,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function add_unregistered_fonts_to_mPDF( $fonts ) {
 
 		foreach( glob( $this->data->template_font_location . '*.{otf,ttf}', GLOB_BRACE ) as $font ) {
-			
+
 			/* Get font shortname */
 			$font_name = basename( $font );
 			$short_name = $this->options->get_font_short_name( substr( $font_name, 0, -4 ) );

--- a/src/views/html/PDF/entry_detailed_pdf.php
+++ b/src/views/html/PDF/entry_detailed_pdf.php
@@ -41,7 +41,7 @@ if (! defined('ABSPATH')) {
 <?php foreach($args['pdfs'] as $pdf): ?>
     <div class="gfpdf_detailed_pdf_container">
         <span><?php echo $pdf['name']; ?></span>
-        <a href="<?php echo $pdf['url']; ?>" target="_blank" class="button"><?php _e('View', 'gravity-forms-pdf-extended' ); ?></a>
-        <a href="<?php echo $pdf['url'] . 'download/'; ?>" target="_blank" class="button"><?php _e('Download', 'gravity-forms-pdf-extended' ); ?></a>
+        <a href="<?php echo $pdf['view']; ?>" target="_blank" class="button"><?php _e('View', 'gravity-forms-pdf-extended' ); ?></a>
+        <a href="<?php echo $pdf['download']; ?>" target="_blank" class="button"><?php _e('Download', 'gravity-forms-pdf-extended' ); ?></a>
     </div>
 <?php endforeach; ?>

--- a/src/views/html/PDF/entry_list_pdf_multiple.php
+++ b/src/views/html/PDF/entry_list_pdf_multiple.php
@@ -38,12 +38,12 @@ if (! defined('ABSPATH')) {
 
 <span class="gf_form_toolbar_settings gf_form_action_has_submenu gfpdf_form_action_has_submenu">
    | <a href="#" title="View PDFs" onclick="return false" class=""><?php _e('View PDFs', 'gravity-forms-pdf-extended' ); ?></a>
-    
+
     <div class="gf_submenu gfpdf_submenu">
         <ul>
-            <?php foreach($args['pdfs'] as $pdf): ?>
+            <?php foreach( $args['pdfs'] as $pdf ): ?>
                 <li>
-                    <a href="<?php echo $pdf['url']; ?>" target="_blank"><?php echo $pdf['name']; ?></a>
+                    <a href="<?php echo ( $args['view'] == 'download' ) ? $pdf['download'] : $pdf['url']; ?>" target="_blank"><?php echo $pdf['name']; ?></a>
                 </li>
             <?php endforeach; ?>
         </ul>

--- a/src/views/html/PDF/entry_list_pdf_single.php
+++ b/src/views/html/PDF/entry_list_pdf_single.php
@@ -36,6 +36,6 @@ if (! defined('ABSPATH')) {
 
 ?>
 
-| <a href="<?php echo $args['url']; ?>" target="_blank">
+| <a href="<?php echo ( $args['view'] == 'download' ) ? $args['pdf']['download'] : $args['pdf']['url']; ?>" target="_blank">
     <?php _e('View PDF', 'gravity-forms-pdf-extended' ); ?>
 </a>

--- a/tests/unit-tests/test-pdf.php
+++ b/tests/unit-tests/test-pdf.php
@@ -575,7 +575,7 @@ class Test_PDF extends WP_UnitTestCase
 	 * @since 4.0
 	 */
 	public function test_view_pdf_entry_list() {
-		
+
 		$results = $this->create_form_and_entries();
 		$form_id = $results['form']['id'];
 		$entry   = $results['entry'];
@@ -592,7 +592,7 @@ class Test_PDF extends WP_UnitTestCase
 	 * @since 4.0
 	 */
 	public function test_view_pdf_entry_detail() {
-		
+
 		$results = $this->create_form_and_entries();
 		$form_id = $results['form']['id'];
 		$entry   = $results['entry'];
@@ -609,7 +609,7 @@ class Test_PDF extends WP_UnitTestCase
 	 * @since 4.0
 	 */
 	public function test_get_pdf_display_list() {
-		global $wp_rewrite;
+		global $wp_rewrite, $gfpdf;
 
 		/* Setup some test data */
 		$results = $this->create_form_and_entries();
@@ -619,10 +619,12 @@ class Test_PDF extends WP_UnitTestCase
 		$pdfs = $this->model->get_pdf_display_list( $entry );
 
 		$this->assertArrayHasKey( 'name', $pdfs[0] );
-		$this->assertArrayHasKey( 'url', $pdfs[0] );
+		$this->assertArrayHasKey( 'view', $pdfs[0] );
+		$this->assertArrayHasKey( 'download', $pdfs[0] );
 
 		$this->assertNotFalse( strpos( $pdfs[0]['name'], 'test-' ) );
-		$this->assertNotFalse( strpos( $pdfs[0]['url'], 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['view'], 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['download'], 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1&#038;action=download' ) );
 
 		/* Process fancy permalinks */
 		$old_permalink_structure = get_option( 'permalink_structure' );
@@ -631,7 +633,8 @@ class Test_PDF extends WP_UnitTestCase
 
 		$pdfs = $this->model->get_pdf_display_list( $entry );
 
-		$this->assertNotFalse( strpos( $pdfs[0]['url'], 'http://example.org/pdf/556690c67856b/' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['view'], 'http://example.org/pdf/556690c67856b/' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['download'], '/download/' ) );		
 
 		$wp_rewrite->set_permalink_structure( $old_permalink_structure );
 		flush_rewrite_rules();
@@ -845,7 +848,7 @@ class Test_PDF extends WP_UnitTestCase
 	 * @since 4.0
 	 */
 	public function test_notifications() {
-		
+
 		/* Setup some test data */
 		$results  = $this->create_form_and_entries();
 		$entry    = $results['entry'];
@@ -916,7 +919,7 @@ class Test_PDF extends WP_UnitTestCase
 	 */
 	public function test_maybe_save_pdf() {
 		global $gfpdf;
-		
+
 		/* Setup some test data */
 		$results  = $this->create_form_and_entries();
 		$entry    = $results['entry'];
@@ -1089,7 +1092,7 @@ class Test_PDF extends WP_UnitTestCase
 		touch( $gfpdf->data->template_font_location . 'aladin.otf' );
 
 		$fonts = $this->model->add_unregistered_fonts_to_mPDF( array() );
-		
+
 		$this->assertArrayHasKey( 'calibri', $fonts );
 		$this->assertArrayHasKey( 'aladin', $fonts );
 	}


### PR DESCRIPTION
The Detailed Entry page had corrupt PDF links when the view was set to "Download". Update get_pdf_display_list() so it returns both view and download links then toggle which one in the view.