### PR TITLE
Steamline Template Variables and Core Styles

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -169,6 +169,10 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Backwards compatibility for our Tier 2 plugin */
 		add_filter( 'gfpdfe_pre_load_template', array( 'PDFRender', 'prepare_ids' ), 1, 8 );
+
+		/* Pre-process our template arguments and automatically render them in PDF */
+		add_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments') );
+		add_filter( 'gfpdf_mpdf_init_class', array( $this->view, 'autoprocess_core_template_options'), 10, 3 );
 	}
 
 	/**

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -86,7 +86,7 @@ class Helper_Misc
 	 * @since 4.0
 	 */
 	public function __construct( LoggerInterface $log, Helper_Abstract_Form $form, Helper_Data $data ) {
-		
+
 		/* Assign our internal variables */
 		$this->log  = $log;
 		$this->form = $form;
@@ -180,7 +180,7 @@ class Helper_Misc
 	public function fix_header_footer( $html ) {
 		try {
 			/* return the modified HTML */
-			return qp( $html, 'img' )->addClass( 'header-footer-img' )->top( 'body' )->children()->html();
+			return htmlqp( $html, 'img' )->addClass( 'header-footer-img' )->top( 'body' )->innerHTML();
 		} catch (Exception $e) {
 			/* if there was any issues we'll just return the $html */
 			return $html;
@@ -455,7 +455,9 @@ class Helper_Misc
 			'lead'      => $entry,
 			'form_data' => $pdf->get_form_data( $entry ),
 
-			'settings' => $settings,
+			'settings'  => $settings,
+
+			'gfpdf'     => $gfpdf,
 
 		), $entry, $settings, $form);
 	}
@@ -613,7 +615,7 @@ class Helper_Misc
 		if ( isset( $settings['template'] ) || isset( $settings['default_template'] ) ) {
 
 			$key = ( isset( $settings['template'] ) ) ? 'template' : 'default_template';
- 
+
 			$current_template = $gfpdf->options->get_form_value( $settings[ $key ] );
 			$template_image   = $this->get_template_image( $current_template );
 
@@ -637,7 +639,7 @@ class Helper_Misc
 	 * @since 4.0
 	 */
 	public function get_allowed_html_tags() {
-		
+
 		$allowedposttags = array(
 				'address' => array(),
 				'a' => array(

--- a/src/helper/fields/Field_Quiz.php
+++ b/src/helper/fields/Field_Quiz.php
@@ -89,7 +89,7 @@ class Field_Quiz extends Helper_Abstract_Fields
 		 * We'll try use our DOM reader to correctly process the HTML, otherwise use string replace
 		 */
 		try {
-			$value = qp( $value, 'img' )->addClass( 'gf-quiz-img' )->top( 'body' )->children()->html();
+			$value = htmlqp( $value, 'img' )->addClass( 'gf-quiz-img' )->top( 'body' )->innerHTML();
 		} catch (Exception $e) {
 			$value = str_replace( '<img ', '<img class="gf-quiz-img" ', $value );
 		}

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -511,7 +511,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		if ( ! empty($pdf_list) ) {
 			$args = array(
 				'pdfs' => $pdf_list
-			);			
+			);
 			$controller->view->entry_detailed_pdf( $args );
 		}
 	}
@@ -1442,5 +1442,32 @@ class Model_PDF extends Helper_Abstract_Model {
 		}
 
 		return new WP_Error( 'Could not find PDF configuration requested' );
+	}
+
+	/**
+	 * Do any preprocessing to our arguments before they are sent to the template
+	 * @param  Array $args
+	 * @return Array
+	 * @since  4.0
+	 */
+	public function preprocess_template_arguments( $args ) {
+
+		if( isset( $args['settings']['header'] ) ) {
+			$args['settings']['header'] 		= $this->misc->fix_header_footer( $args['settings']['header'] );
+		}
+
+		if( isset( $args['settings']['first_header'] ) ) {
+			$args['settings']['first_header'] 	= $this->misc->fix_header_footer( $args['settings']['first_header'] );
+		}
+
+		if( isset( $args['settings']['footer'] ) ) {
+			$args['settings']['footer'] 		= $this->misc->fix_header_footer( $args['settings']['footer'] );
+		}
+
+		if( isset( $args['settings']['first_footer'] ) ) {
+			$args['settings']['first_footer'] 	= $this->misc->fix_header_footer( $args['settings']['first_footer'] );
+		}
+
+		return $args;
 	}
 }

--- a/src/views/View_PDF.php
+++ b/src/views/View_PDF.php
@@ -449,4 +449,22 @@ class View_PDF extends Helper_Abstract_View
 
 		echo apply_filters( 'gfpdf_field_page_name_html', ob_get_clean(), $page, $field, $form );
 	}
+
+	/**
+	 * Automatically render our core PDF fields, a styles in templates to simplify there usage for users
+	 * @param  Object $mpdf     The mPDF object
+	 * @param  Array $entry     The Gravity Form entry being processed
+	 * @param  Array $settings  The current PDF settings
+	 */
+	public function autoprocess_core_template_options( $mpdf, $entry, $settings ) {
+
+		if( ! $mpdf instanceof mPDF ) {
+			return $mpdf;
+		}
+
+		$html = $this->load( 'core_template_styles', array( 'settings' => $settings ), false );
+		$mpdf->WriteHTML( $html );
+
+		return $mpdf;
+	}
 }

--- a/src/views/html/PDF/core_template_styles.php
+++ b/src/views/html/PDF/core_template_styles.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * The styles needed to display our core PDF styles like header, footer, font and colour
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2015, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+$font                 = ( ! empty( $settings['font'] ) ) 			? $settings['font'] : 'DejavuSansCondensed';
+$font_colour          = ( ! empty( $settings['font_colour'] ) ) 	? $settings['font_colour'] : '#333';
+$font_size            = ( ! empty( $settings['font_size'] ) ) 		? $settings['font_size'] : '9';
+
+$header               = ( ! empty( $settings['header'] ) ) 			? $settings['header'] : '';
+$footer               = ( ! empty( $settings['footer'] ) ) 			? $settings['footer'] : '';
+$first_header         = ( ! empty( $settings['first_header'] ) ) 	? $settings['first_header'] : '';
+$first_footer         = ( ! empty( $settings['first_footer'] ) ) 	? $settings['first_footer'] : '';
+
+$background_img       = ( ! empty( $settings['background'] ) )  	? $settings['background'] : '';
+
+?>
+
+
+<style>
+    @page {
+        margin: 10mm;
+
+        <?php if ( ! empty($header) ) : ?>
+            header: html_TemplateHeader;
+            margin-header: 5mm;
+        <?php endif; ?>
+
+        <?php if ( ! empty($footer) ) : ?>
+            footer: html_TemplateFooter;
+            margin-footer: 5mm;
+        <?php endif; ?>
+
+        <?php if ( ! empty($background_img) ) : ?>
+            background-image: url(<?php echo $background_img; ?>) no-repeat 0 0;
+            background-image-resize: 4;
+        <?php endif; ?>
+    }
+
+    @page :first {
+        <?php if ( ! empty($first_header) ) : ?>
+            header: html_TemplateFirstHeader;
+            margin-header: 5mm;
+        <?php endif; ?>
+
+        <?php if ( ! empty($first_footer) ) : ?>
+            footer: html_TemplateFirstFooter;
+            margin-footer: 5mm;
+        <?php endif; ?>
+    }
+
+	body, table th, table td, ul li, ol li {
+        color: <?php echo $font_colour; ?>;
+        font-size: <?php echo $font_size; ?>pt;
+        font-family: <?php echo $font; ?>, sans-serif;
+    }
+
+    .header-footer-img {
+        width: auto !important;
+        max-height: 25mm;
+    }
+
+</style>
+
+<htmlpageheader name="TemplateFirstHeader">
+    <div id="first_header">
+        <?php echo $first_header; ?>
+    </div>
+</htmlpageheader>
+
+<htmlpageheader name="TemplateHeader">
+    <div id="header">
+        <?php echo $header; ?>
+    </div>
+</htmlpageheader>
+
+<htmlpagefooter name="TemplateFirstFooter">
+    <div id="first_footer">
+        <?php echo $first_footer; ?>
+    </div>
+</htmlpagefooter>
+
+<htmlpagefooter name="TemplateFooter">
+    <div class="footer">
+        <?php echo $footer; ?>
+    </div>
+</htmlpagefooter>

--- a/src/views/html/PDF/entry_list_pdf_multiple.php
+++ b/src/views/html/PDF/entry_list_pdf_multiple.php
@@ -43,7 +43,7 @@ if (! defined('ABSPATH')) {
         <ul>
             <?php foreach( $args['pdfs'] as $pdf ): ?>
                 <li>
-                    <a href="<?php echo ( $args['view'] == 'download' ) ? $pdf['download'] : $pdf['url']; ?>" target="_blank"><?php echo $pdf['name']; ?></a>
+                    <a href="<?php echo ( $args['view'] == 'download' ) ? $pdf['download'] : $pdf['view']; ?>" target="_blank"><?php echo $pdf['name']; ?></a>
                 </li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
- Steamline the PDF templates so core styles like font, colour, size and headers/footers don't need to be manually set by the user
- Make $gfpdf available to templates automatically
- Preprocess header/footer settings so users don't need to do so via the template

Fixes #39, #41, #57, #42

Remove the "!important" tag from the page font color